### PR TITLE
Wait for last byte to be sent before continuing

### DIFF
--- a/USISerialSend/USISerialSend.ino
+++ b/USISerialSend/USISerialSend.ino
@@ -153,12 +153,8 @@ void loop() {
     char message[] = "USI Serial\r\n";
     uint8_t len = sizeof(message)-1;
     for (uint8_t i = 0; i<len; i++)
-    {
-        while (!usiserial_send_available())
-        {
-            // Wait for last send to complete
-        }
         usiserial_send_byte(message[i]);
-    }
+    while (!usiserial_send_available()) {}    // Wait for last send to complete
+
     delay(1000);
 }


### PR DESCRIPTION
The send_byte function already waits for the USI to become available. So
there is no need to wait in the for loop. However you should wait after all
bytes have been sent to continue safely, as the interrupt makes sure the
timers are given back to the Arduino core.

This example doesn't work right now as the Arduino core tries to delay using
timers still in use by the USI because the interrupt hasn't fired yet.